### PR TITLE
Fix #7 - Hide secret key when one has been set.

### DIFF
--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -140,8 +140,8 @@ class MollieSettingsHolder(BasePaymentProvider):
                      validators=(
                          MollieKeyValidator(['live_', 'test_']),
                      ),
-                     widget=SecretKeyInput(secret_key=self.settings.api_key),
-                     required=bool(self.settings.api_key),
+                     widget=SecretKeyInput(secret_key=self.settings.api_key or ''),
+                     required=not bool(self.settings.api_key),
                  )),
             ]
         d = OrderedDict(


### PR DESCRIPTION
As suggested in #8, this PR hides the current value of the secret key for the end-user. 