### PR TITLE
Rework OAuth2 refresh logic

### DIFF
--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -409,6 +409,7 @@ class MollieMethod(BasePaymentProvider):
         if self.settings.connect_client_id and self.settings.access_token:
             body['testmode'] = refund.payment.info_data.get('mode', 'live') == 'test'
         try:
+            refresh_mollie_token(self.event, True)
             req = requests.post(
                 'https://api.mollie.com/v2/payments/{}/refunds'.format(payment),
                 json=body,
@@ -505,6 +506,7 @@ class MollieMethod(BasePaymentProvider):
         except:
             pass
         try:
+            refresh_mollie_token(self.event, True)
             req = requests.post(
                 'https://api.mollie.com/v2/payments',
                 json=self._get_payment_body(payment),

--- a/pretix_mollie/utils.py
+++ b/pretix_mollie/utils.py
@@ -12,11 +12,17 @@ from pretix.helpers.urls import build_absolute_uri
 logger = logging.getLogger(__name__)
 
 
-def refresh_mollie_token(event, disable=True):
-    # Rate limit
+def refresh_mollie_token(event, conditional=False):
     rt = event.settings.payment_mollie_refresh_token
     if not rt:
         return False
+
+    if conditional:
+        # Only execute if refresh is near
+        if event.settings.payment_mollie_expires and event.settings.payment_mollie_expires - time.time() < 60:
+            return False  # no refresh necessary
+
+    # Prevent concurrent execution
     h = hashlib.sha1(rt.encode()).hexdigest()
     if cache.get('mollie_refresh_{}'.format(h)):
         return False
@@ -34,12 +40,6 @@ def refresh_mollie_token(event, disable=True):
         })
     except Exception as e:
         logger.exception('Unable to refresh mollie token')
-        if float(event.settings.payment_mollie_expires) > time.time() and not \
-                event.settings.payment_mollie_api_key and disable:
-            event.settings.payment_mollie__enabled = False
-            event.log_action('pretix_mollie.event.disabled', {
-                'reason': str(e)
-            })
         return False
     else:
         if resp.status_code == 200:

--- a/pretix_mollie/views.py
+++ b/pretix_mollie/views.py
@@ -151,6 +151,7 @@ def handle_payment(payment, mollie_id, retry=True):
     else:
         qp = ''
     try:
+        refresh_mollie_token(payment.order.event, True)
         resp = requests.get(
             'https://api.mollie.com/v2/payments/' + mollie_id + '?' + qp,
             headers=pprov.request_headers


### PR DESCRIPTION
As it turns out, our whole dance around disabling the payment provider in some cases is no longer required since Mollie refresh tokens no longer expire (like they used to)!