### PR TITLE
BankTransfer: Generate invoice after payment if invoice_generate=paid (Z#23144775)

### DIFF
--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -288,6 +288,17 @@ class MollieSettingsHolder(BasePaymentProvider):
                          }
                      )
                  )),
+                ('method_banktransfer_invoice_immediately',
+                 forms.BooleanField(
+                     label=_('Create an invoice for orders using bank transfer immediately if the event is otherwise '
+                             'configured to create invoices after payment is completed.'),
+                     required=False,
+                     widget=forms.CheckboxInput(
+                         attrs={
+                             "data-display-dependency": "#id_payment_mollie_method_banktransfer",
+                         }
+                     ),
+                 )),
                 ('method_klarnapaynow',
                  forms.BooleanField(
                      label=_('Klarna Pay now'),
@@ -893,7 +904,7 @@ class MollieBanktransfer(MolliePaymentMethod):
 
         p_orig.refresh_from_db()
 
-        if payment.order.event.settings.get('invoice_generate') == 'paid':
+        if payment.order.event.settings.get('invoice_generate') == 'paid' and self.settings.get('method_banktransfer_invoice_immediately', False, as_type=bool):
             i = payment.order.invoices.filter(is_cancellation=False).last()
             has_active_invoice = i and not i.canceled
             if (not has_active_invoice or payment.order.invoice_dirty) and invoice_qualified(payment.order):

--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -24,6 +24,7 @@ from django.utils.translation import pgettext, gettext_lazy as _
 from i18nfield.strings import LazyI18nString
 
 from pretix.base.reldate import RelativeDateField, RelativeDateWrapper, RelativeDateWidget, BASE_CHOICES
+from pretix.base.services.invoices import generate_cancellation, generate_invoice, invoice_qualified
 from pretix.helpers import OF_SELF
 from pretix_mollie.utils import refresh_mollie_token
 from requests import HTTPError
@@ -286,17 +287,6 @@ class MollieSettingsHolder(BasePaymentProvider):
                              "data-display-dependency": "#id_payment_mollie_method_banktransfer",
                          }
                      )
-                 )),
-                ('method_banktransfer_invoice_immediately',
-                 forms.BooleanField(
-                     label=_('Create an invoice for orders using bank transfer immediately if the event is otherwise '
-                             'configured to create invoices after payment is completed.'),
-                     required=False,
-                     widget=forms.CheckboxInput(
-                         attrs={
-                             "data-display-dependency": "#id_payment_mollie_method_banktransfer",
-                         }
-                     ),
                  )),
                 ('method_klarnapaynow',
                  forms.BooleanField(
@@ -887,9 +877,6 @@ class MollieBanktransfer(MolliePaymentMethod):
     verbose_name = _('Bank transfer via Mollie')
     public_name = _('Bank transfer')
 
-    @property
-    def requires_invoice_immediately(self):
-        return self.settings.get('method_banktransfer_invoice_immediately', False, as_type=bool)
 
     def execute_payment(self, request: HttpRequest, payment: OrderPayment, retry=True):
         err = None
@@ -905,6 +892,18 @@ class MollieBanktransfer(MolliePaymentMethod):
             raise err
 
         p_orig.refresh_from_db()
+
+        if payment.order.event.settings.get('invoice_generate') == 'paid':
+            i = payment.order.invoices.filter(is_cancellation=False).last()
+            has_active_invoice = i and not i.canceled
+            if (not has_active_invoice or payment.order.invoice_dirty) and invoice_qualified(payment.order):
+                if has_active_invoice:
+                    generate_cancellation(i)
+                i = generate_invoice(payment.order)
+                payment.order.log_action('pretix.event.order.invoice.generated', data={
+                    'invoice': i.pk
+                })
+
         return  # no redirect necessary for this method
 
     def _get_payment_body(self, payment):


### PR DESCRIPTION
As of right now, the invoice-generation for Bank Transfer did not work as expected: the `requires_invoice_immediately` caused the invoice to be generated *before* the payment, thus generating an invoice without the Mollie payment information.

This change:
- Defaults the `requires_invoice_immediately` property back to `False` (since we do not want the invoice before the payment)
- Adds handling for invoice-generation after the payment if `invoice_generate` is set to `paid` if `requires_invoice_immediately` is `True`.
