### PR TITLE
Avoid useless requests (Z#23190000)

### DIFF
--- a/pretix_mollie/views.py
+++ b/pretix_mollie/views.py
@@ -236,7 +236,7 @@ def handle_payment(payment, mollie_id, retry=True):
         resp.raise_for_status()
         data = resp.json()
 
-        if data.get("amountRefunded") and data.get("status") == "paid":
+        if data.get("amountRefunded") and data["amountRefunded"].get("value") != "0.00" and data.get("status") == "paid":
             refundsresp = requests.get(
                 "https://api.mollie.com/v2/payments/" + mollie_id + "/refunds?" + qp,
                 headers=pprov.request_headers,
@@ -246,7 +246,7 @@ def handle_payment(payment, mollie_id, retry=True):
         else:
             refunds = []
 
-        if data.get("status") == "paid":
+        if data.get("amountChargedBack") and data["amountChargedBack"].get("value") != "0.00" and data.get("status") == "paid":
             chargebacksresp = requests.get(
                 "https://api.mollie.com/v2/payments/"
                 + mollie_id


### PR DESCRIPTION
Mollie seems to have occasional issues with their eventual consistency, causing the /refunds call to fail with 404 directly after a payment was created. And apparently they started sending `amountRefunded: {currency: "EUR", "value": "0.00"}` instead of `amountRefunded: null` at least for some payment methods. So let's skip these extra requests for that case.