### PR TITLE
Fix invalid due date

### DIFF
--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -1097,6 +1097,24 @@ class MollieBanktransfer(MolliePaymentMethod):
     method = "banktransfer"
     public_name = _("Bank transfer")
 
+    def _validate_due_date(self, due_date):
+        """Validate and constrain dueDate according to Mollie requirements.
+        
+        The minimum date is tomorrow, and the maximum date is 100 days after tomorrow.
+        If the date is outside these bounds, it will be adjusted.
+        """
+        from django.utils.timezone import now as tz_now
+        
+        today = tz_now().astimezone(zoneinfo.ZoneInfo(self.event.timezone)).date()
+        min_date = today + timedelta(days=1)  # tomorrow
+        max_date = today + timedelta(days=101)  # 100 days after tomorrow
+        
+        if due_date < min_date:
+            return min_date
+        elif due_date > max_date:
+            return max_date
+        return due_date
+
     def execute_payment(self, request: HttpRequest, payment: OrderPayment, retry=True):
         err = None
         with transaction.atomic():
@@ -1143,10 +1161,10 @@ class MollieBanktransfer(MolliePaymentMethod):
         try:
             refresh_mollie_token(self.event, True)
 
+            due_date = payment.order.payment_term_expire_date.date()
+            due_date = self._validate_due_date(due_date)
             body = {
-                "dueDate": (
-                    payment.order.payment_term_expire_date.date() + timedelta(days=1)
-                ).isoformat()
+                "dueDate": due_date.isoformat()
             }
             if self.settings.connect_client_id and self.settings.access_token:
                 body["testmode"] = payment.info_data.get("mode", "live") == "test"
@@ -1182,9 +1200,9 @@ class MollieBanktransfer(MolliePaymentMethod):
 
     def _get_payment_body(self, payment):
         body = super()._get_payment_body(payment)
-        body["dueDate"] = (
-            payment.order.payment_term_expire_date.date() + timedelta(days=1)
-        ).isoformat()
+        due_date = payment.order.payment_term_expire_date.date()
+        due_date = self._validate_due_date(due_date)
+        body["dueDate"] = due_date.isoformat()
         return body
 
     def order_pending_mail_render(self, order, payment) -> str:

--- a/pretix_mollie/payment.py
+++ b/pretix_mollie/payment.py
@@ -1144,7 +1144,9 @@ class MollieBanktransfer(MolliePaymentMethod):
             refresh_mollie_token(self.event, True)
 
             body = {
-                "dueDate": (payment.order.expires.date() + timedelta(days=1)).isoformat(),
+                "dueDate": (
+                    payment.order.payment_term_expire_date.date() + timedelta(days=1)
+                ).isoformat()
             }
             if self.settings.connect_client_id and self.settings.access_token:
                 body["testmode"] = payment.info_data.get("mode", "live") == "test"
@@ -1180,7 +1182,9 @@ class MollieBanktransfer(MolliePaymentMethod):
 
     def _get_payment_body(self, payment):
         body = super()._get_payment_body(payment)
-        body["dueDate"] = (payment.order.expires.date() + timedelta(days=1)).isoformat()
+        body["dueDate"] = (
+            payment.order.payment_term_expire_date.date() + timedelta(days=1)
+        ).isoformat()
         return body
 
     def order_pending_mail_render(self, order, payment) -> str:


### PR DESCRIPTION
This pull request improves how due dates are handled for Mollie bank transfer payments by introducing stricter validation to ensure compliance with Mollie's requirements. The main changes involve centralizing and constraining the calculation of payment due dates, so they always fall within the allowed window (from tomorrow up to 100 days after tomorrow). This fix also ensures that the due date is now based on the order's `payment_term_expire_date` instead of the previous `expires` date.

Key changes:

**Due date validation:**
* Added a new method `_validate_due_date` in `MollieBanktransfer` to ensure the due date is not earlier than tomorrow and not later than 100 days after tomorrow, automatically adjusting dates that fall outside this range.

**Consistent due date calculation:**
* Updated both `update_payment_expiry` and `_get_payment_body` to use the new `_validate_due_date` method, ensuring that all due dates sent to Mollie are properly validated and consistent throughout the codebase.

Fixes #64
Ref [Mollie Docs for `dueDate`](https://docs.mollie.com/reference/extra-payment-parameters#duedate-string)