### PR TITLE
Remove legacy webhook

### DIFF
--- a/pretix_mollie/urls.py
+++ b/pretix_mollie/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path, re_path
 from pretix.multidomain import event_path, event_url
 
 from .views import (
-    ReturnView, WebhookView, Webhook2View, oauth_disconnect, oauth_return, redirect_view,
+    ReturnView, Webhook2View, oauth_disconnect, oauth_return, redirect_view,
 )
 
 event_patterns = [
@@ -10,12 +10,6 @@ event_patterns = [
         "mollie/",
         include(
             [
-                event_url(
-                    r"^webhook/(?P<payment>[0-9]+)/$",
-                    WebhookView.as_view(),
-                    name="webhook",
-                    require_live=False,
-                ),
                 event_path(
                     "webhook2/<str:order>/<str:hash>/<int:payment>/",
                     Webhook2View.as_view(),

--- a/pretix_mollie/views.py
+++ b/pretix_mollie/views.py
@@ -588,33 +588,6 @@ class ReturnView(MollieOrderView, View):
 
 
 @method_decorator(csrf_exempt, "dispatch")
-class WebhookView(View):
-    def post(self, request, *args, **kwargs):
-        # old-style webhook url, deprecated as of 2026-06-11
-        if "/webhook2/" in self.payment.info_data.get("webhookUrl", ""):
-            return HttpResponse(status=404)
-        try:
-            if request.POST.get("id") and request.POST["id"].startswith("ord_"):
-                # todo: remove after some time, as it is deprecated (noted on 2025-07-16)
-                handle_order(self.payment, request.POST.get("id"))
-            else:
-                handle_payment(self.payment, request.POST.get("id"))
-        except LockTimeoutException:
-            return HttpResponse(status=503)
-        except Quota.QuotaExceededException:
-            pass
-        return HttpResponse(status=200)
-
-    @cached_property
-    def payment(self):
-        return get_object_or_404(
-            OrderPayment.objects.filter(order__event=self.request.event),
-            pk=self.kwargs["payment"],
-            provider__startswith="mollie",
-        )
-
-
-@method_decorator(csrf_exempt, "dispatch")
 class Webhook2View(MollieOrderView, View):
     def post(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
Marked as draft as this should be merged not before 2027, so no old-style webhooks fail (half a year should be enough for all credit card payments to be settled)